### PR TITLE
Set wombat256mod by default

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -24,7 +24,7 @@ Plugin 'Lokaltog/powerline'                 " Powerline fonts plugin
 Plugin 'fisadev/FixedTaskList.vim'  	    " Pending tasks list
 Plugin 'rosenfeld/conque-term'      	    " Consoles as buffers
 Plugin 'tpope/vim-surround'                 " Parentheses, brackets, quotes, XML tags, and more
-Plugin 'git@github.com:sheerun/vim-wombat-scheme.git'   " Wombat colorscheme
+Plugin 'flazz/vim-colorschemes'             " Colorschemes
 
 "-------------------=== Snippets support ===--------------------
 Plugin 'garbas/vim-snipmate'                " Snippets manager
@@ -55,6 +55,10 @@ filetype plugin indent on
 "" General settings
 "=====================================================
 syntax enable                               " syntax highlight
+
+set t_Co=256                                " set 256 colors
+colorscheme wombat256mod                    " set color scheme
+
 set number                                  " show line numbers
 set ruler
 set ttyfast                                 " terminal acceleration
@@ -67,9 +71,6 @@ set autoindent                              " indent when moving to the next lin
 
 set cursorline                              " shows line under the cursor's line
 set showmatch                               " shows matching part of bracket pairs (), [], {}
-
-set t_Co=256                                " set 256 colors
-colorscheme wombat                          " set color scheme
 
 set enc=utf-8	                            " utf-8 by default
 


### PR DESCRIPTION
@boonya 

Hi! Can you please review it?

I found that there is some kind of mess with wombat colorschemes (very lot of custom modifications with the same names), so:

1) I added more or less official repo with colorschemes - https://github.com/flazz/vim-colorschemes
2) I set wombat256mod colorscheme by default. It has some differences from which one I've used before, but it looks like that it works for me best.
