### PR TITLE
Remove Python tagbar close on quit

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -127,7 +127,6 @@ let g:airline_powerline_fonts=1
 let g:tagbar_autofocus=0
 let g:tagbar_width=42
 autocmd BufEnter *.py :call tagbar#autoopen(0)
-autocmd BufWinLeave *.py :TagbarClose
 
 "=====================================================
 "" NERDTree settings


### PR DESCRIPTION
Your work is pretty sweet, and I've been using it for a few years now. Thanks a lot!

As many people reported in #32 , the tagbar close on Python files causes an `E855` error on various systems.

Here's the `vimrc` with the famous line 130 removed :)